### PR TITLE
add get slice index api

### DIFF
--- a/async-remote-lib/src/dslice.cpp
+++ b/async-remote-lib/src/dslice.cpp
@@ -98,20 +98,18 @@ int64_t GetSliceSize(void* obj) {
   return ((DSliObject*)obj)->GetPtr()->Size();
 }
 
-/*
-void* GetSliceIndexString(DSliObject* obj, int64_t idx) {
-  return static_cast<DStrObject*>(obj->GetPtr()->Index(idx).str_obj);
+void* GetSliceIndexString(void* obj, int64_t idx) {
+  return ((DSliObject*)obj)->GetPtr()->Index(idx).str_obj;
 }
 
-int64_t* GetSliceIndexInt(DSliObject* obj, int64_t idx) {
-  return &(obj->GetPtr()->Index(idx).num64);
+int64_t* GetSliceIndexInt(void* obj, int64_t idx) {
+  return &((DSliObject*)obj)->GetPtr()->Index(idx).num64;
 }
 
-double* GetSliceIndexDouble(DSliObject* obj, int64_t idx) {
-  return &(obj->GetPtr()->Index(idx).num_double);
+double* GetSliceIndexDouble(void* obj, int64_t idx) {
+  return &((DSliObject*)obj)->GetPtr()->Index(idx).num_double;
 }
 
-void* GetSliceIndexFuture(DSliObject* obj, int64_t idx) {
-  return obj->GetPtr()->Index(idx).future_obj;
+void* GetSliceIndexFuture(void* obj, int64_t idx) {
+  return ((DSliObject*)obj)->GetPtr()->Index(idx).future_obj;
 }
-*/

--- a/async-remote-lib/src/dslice.h
+++ b/async-remote-lib/src/dslice.h
@@ -44,7 +44,7 @@ void* SliceAppend(void* obj, ...);
 
 int64_t GetSliceSize(void* obj);
 
-/*
+
 void* GetSliceIndexString(void* obj, int64_t idx);
 
 int64_t* GetSliceIndexInt(void* obj, int64_t idx);
@@ -52,7 +52,6 @@ int64_t* GetSliceIndexInt(void* obj, int64_t idx);
 double* GetSliceIndexDouble(void* obj, int64_t idx);
 
 void* GetSliceIndexFuture(void* obj, int64_t idx);
-*/
 }
 
 


### PR DESCRIPTION
按照刚刚meeting里说的，提供了slice下标操作，**返回对应元素的指针** @lhxxh @wy2249 

```
void* GetSliceIndexString(void* obj, int64_t idx);

int64_t* GetSliceIndexInt(void* obj, int64_t idx);

double* GetSliceIndexDouble(void* obj, int64_t idx);

void* GetSliceIndexFuture(void* obj, int64_t idx);

```