### PR TITLE
fixed: void type return

### DIFF
--- a/digo-compiler/codegen.ml
+++ b/digo-compiler/codegen.ml
@@ -361,7 +361,7 @@ let translate(functions) =
         | SFunctionCall(f_name,args)                                           ->             
           let (fdef,fd) = find_func f_name in
           let llargs = List.map (expr builder) args in 
-          let result = f_name^"_result" in 
+          let result = (match fd.styp with [VoidType] -> "" | _ -> f_name ^ "_result") in 
           let build_func_call = match fd.sann with
             FuncNormal -> build_call fdef (Array.of_list llargs) result builder
             | _ ->

--- a/digo-compiler/test/test-readfile.digo
+++ b/digo-compiler/test/test-readfile.digo
@@ -6,4 +6,91 @@ func digo_main() void {
     res = read(s)
 
     res2 := read(s)
+
+    test(s)
 }
+
+func test(s string) void {
+    read(s)
+}
+
+/*
+
+; ModuleID = 'Digo'
+source_filename = "Digo"
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-pc-linux-gnu"
+
+@createstr_ptr = private unnamed_addr constant [14 x i8] c"/tmp/test.txt\00"
+
+declare void @print(i8*, ...)
+
+declare void @println(i8*, ...)
+
+declare i8* @CreateString(i8*)
+
+declare i8* @CreateEmptyString()
+
+declare i8* @AddString(i8*, i8*)
+
+declare i64 @CompareString(i8*, i8*)
+
+declare i8* @CloneString(i8*)
+
+declare i64 @GetStringSize(i8*)
+
+declare i8* @CreateSlice(i64)
+
+declare i8* @SliceAppend(i8*, ...)
+
+declare i8* @SliceSlice(i8*, i64, i64)
+
+declare i64 @GetSliceSize(i8*)
+
+declare double @SetSliceIndexDouble(i8*, i64, double)
+
+declare i8* @SetSliceIndexFuture(i8*, i64, i8*)
+
+declare i8* @SetSliceIndexString(i8*, i64, i8*)
+
+declare i64 @SetSliceIndexInt(i8*, i64, i64)
+
+declare double @GetSliceIndexDouble(i8*, i64)
+
+declare i8* @GetSliceIndexFuture(i8*, i64)
+
+declare i8* @GetSliceIndexString(i8*, i64)
+
+declare i64 @GetSliceIndexInt(i8*, i64)
+
+declare i8* @ReadFile(i8*)
+
+define void @digo_main() {
+entry:
+  %s = alloca i8*
+  %createstr = call i8* @CreateString(i8* getelementptr inbounds ([14 x i8], [14 x i8]* @createstr_ptr, i32 0, i32 0))
+  %clonestr = call i8* @CloneString(i8* %createstr)
+  store i8* %clonestr, i8** %s
+  %res = alloca i8*
+  %s1 = load i8*, i8** %s
+  %read_file = call i8* @ReadFile(i8* %s1)
+  store i8* %read_file, i8** %res
+  %res2 = alloca i8*
+  %s2 = load i8*, i8** %s
+  %read_file3 = call i8* @ReadFile(i8* %s2)
+  store i8* %read_file3, i8** %res2
+  %s4 = load i8*, i8** %s
+  call void @test(i8* %s4)
+  ret void
+}
+
+define void @test(i8* %s) {
+entry:
+  %s1 = alloca i8*
+  store i8* %s, i8** %s1
+  %s2 = load i8*, i8** %s1
+  %read_file = call i8* @ReadFile(i8* %s2)
+  ret void
+}
+
+*/


### PR DESCRIPTION
This pr fixes the bug when calling a void type function, listed in issue #53.

Test Code
```
func testfloat(a float, b float) void {
  println("%f", a + b)
  println("%f", a - b)
  println("%f", a * b)
  println("%f", a / b)
  println("%f", a == b)
  println("%f", a == a)
  println("%f", a != b)
  println("%f", a != a)
  println("%f", a > b)
  println("%f", a >= b)
  println("%f", a < b)
  println("%f", a <= b)
}

func digo_main() void {
  c := 42.0
  d := 3.14159

  testfloat(c, d)
  testfloat(d, d)
}
```

Output
```
; ModuleID = 'Digo'
source_filename = "Digo"
target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
target triple = "x86_64-pc-linux-gnu"

@createstr_ptr = private unnamed_addr constant [3 x i8] c"%f\00"
@createstr_ptr.1 = private unnamed_addr constant [3 x i8] c"%f\00"
@createstr_ptr.2 = private unnamed_addr constant [3 x i8] c"%f\00"
@createstr_ptr.3 = private unnamed_addr constant [3 x i8] c"%f\00"
@createstr_ptr.4 = private unnamed_addr constant [3 x i8] c"%f\00"
@createstr_ptr.5 = private unnamed_addr constant [3 x i8] c"%f\00"
@createstr_ptr.6 = private unnamed_addr constant [3 x i8] c"%f\00"
@createstr_ptr.7 = private unnamed_addr constant [3 x i8] c"%f\00"
@createstr_ptr.8 = private unnamed_addr constant [3 x i8] c"%f\00"
@createstr_ptr.9 = private unnamed_addr constant [3 x i8] c"%f\00"
@createstr_ptr.10 = private unnamed_addr constant [3 x i8] c"%f\00"
@createstr_ptr.11 = private unnamed_addr constant [3 x i8] c"%f\00"

declare void @print(i8*, ...)

declare void @println(i8*, ...)

declare i8* @CreateString(i8*)

declare i8* @CreateEmptyString()

declare i8* @AddString(i8*, i8*)

declare i64 @CompareString(i8*, i8*)

declare i8* @CloneString(i8*)

declare i64 @GetStringSize(i8*)

declare i8* @CreateSlice(i64)

declare i8* @SliceAppend(i8*, ...)

declare i8* @SliceSlice(i8*, i64, i64)

declare i64 @GetSliceSize(i8*)

declare double @SetSliceIndexDouble(i8*, i64, double)

declare i8* @SetSliceIndexFuture(i8*, i64, i8*)

declare i8* @SetSliceIndexString(i8*, i64, i8*)

declare i64 @SetSliceIndexInt(i8*, i64, i64)

declare double @GetSliceIndexDouble(i8*, i64)

declare i8* @GetSliceIndexFuture(i8*, i64)

declare i8* @GetSliceIndexString(i8*, i64)

declare i64 @GetSliceIndexInt(i8*, i64)

declare i8* @ReadFile(i8*)

define void @testfloat(double %a, double %b) {
entry:
  %a1 = alloca double
  store double %a, double* %a1
  %b2 = alloca double
  store double %b, double* %b2
  %createstr = call i8* @CreateString(i8* getelementptr inbounds ([3 x i8], [3 x i8]* @createstr_ptr, i32 0, i32 0))
  %a3 = load double, double* %a1
  %b4 = load double, double* %b2
  %tmp = fadd double %a3, %b4
  call void (i8*, ...) @println(i8* %createstr, double %tmp)
  %createstr5 = call i8* @CreateString(i8* getelementptr inbounds ([3 x i8], [3 x i8]* @createstr_ptr.1, i32 0, i32 0))
  %a6 = load double, double* %a1
  %b7 = load double, double* %b2
  %tmp8 = fsub double %a6, %b7
  call void (i8*, ...) @println(i8* %createstr5, double %tmp8)
  %createstr9 = call i8* @CreateString(i8* getelementptr inbounds ([3 x i8], [3 x i8]* @createstr_ptr.2, i32 0, i32 0))
  %a10 = load double, double* %a1
  %b11 = load double, double* %b2
  %tmp12 = fmul double %a10, %b11
  call void (i8*, ...) @println(i8* %createstr9, double %tmp12)
  %createstr13 = call i8* @CreateString(i8* getelementptr inbounds ([3 x i8], [3 x i8]* @createstr_ptr.3, i32 0, i32 0))
  %a14 = load double, double* %a1
  %b15 = load double, double* %b2
  %tmp16 = fdiv double %a14, %b15
  call void (i8*, ...) @println(i8* %createstr13, double %tmp16)
  %createstr17 = call i8* @CreateString(i8* getelementptr inbounds ([3 x i8], [3 x i8]* @createstr_ptr.4, i32 0, i32 0))
  %a18 = load double, double* %a1
  %b19 = load double, double* %b2
  %tmp20 = fcmp oeq double %a18, %b19
  call void (i8*, ...) @println(i8* %createstr17, i1 %tmp20)
  %createstr21 = call i8* @CreateString(i8* getelementptr inbounds ([3 x i8], [3 x i8]* @createstr_ptr.5, i32 0, i32 0))
  %a22 = load double, double* %a1
  %a23 = load double, double* %a1
  %tmp24 = fcmp oeq double %a22, %a23
  call void (i8*, ...) @println(i8* %createstr21, i1 %tmp24)
  %createstr25 = call i8* @CreateString(i8* getelementptr inbounds ([3 x i8], [3 x i8]* @createstr_ptr.6, i32 0, i32 0))
  %a26 = load double, double* %a1
  %b27 = load double, double* %b2
  %tmp28 = fcmp one double %a26, %b27
  call void (i8*, ...) @println(i8* %createstr25, i1 %tmp28)
  %createstr29 = call i8* @CreateString(i8* getelementptr inbounds ([3 x i8], [3 x i8]* @createstr_ptr.7, i32 0, i32 0))
  %a30 = load double, double* %a1
  %a31 = load double, double* %a1
  %tmp32 = fcmp one double %a30, %a31
  call void (i8*, ...) @println(i8* %createstr29, i1 %tmp32)
  %createstr33 = call i8* @CreateString(i8* getelementptr inbounds ([3 x i8], [3 x i8]* @createstr_ptr.8, i32 0, i32 0))
  %a34 = load double, double* %a1
  %b35 = load double, double* %b2
  %tmp36 = fcmp ogt double %a34, %b35
  call void (i8*, ...) @println(i8* %createstr33, i1 %tmp36)
  %createstr37 = call i8* @CreateString(i8* getelementptr inbounds ([3 x i8], [3 x i8]* @createstr_ptr.9, i32 0, i32 0))
  %a38 = load double, double* %a1
  %b39 = load double, double* %b2
  %tmp40 = fcmp oge double %a38, %b39
  call void (i8*, ...) @println(i8* %createstr37, i1 %tmp40)
  %createstr41 = call i8* @CreateString(i8* getelementptr inbounds ([3 x i8], [3 x i8]* @createstr_ptr.10, i32 0, i32 0))
  %a42 = load double, double* %a1
  %b43 = load double, double* %b2
  %tmp44 = fcmp olt double %a42, %b43
  call void (i8*, ...) @println(i8* %createstr41, i1 %tmp44)
  %createstr45 = call i8* @CreateString(i8* getelementptr inbounds ([3 x i8], [3 x i8]* @createstr_ptr.11, i32 0, i32 0))
  %a46 = load double, double* %a1
  %b47 = load double, double* %b2
  %tmp48 = fcmp ole double %a46, %b47
  call void (i8*, ...) @println(i8* %createstr45, i1 %tmp48)
  ret void
}

define void @digo_main() {
entry:
  %c = alloca double
  store double 4.200000e+01, double* %c
  %d = alloca double
  store double 3.141590e+00, double* %d
  %c1 = load double, double* %c
  %d2 = load double, double* %d
  call void @testfloat(double %c1, double %d2)
  %d3 = load double, double* %d
  %d4 = load double, double* %d
  call void @testfloat(double %d3, double %d4)
  ret void
}
```
